### PR TITLE
install heroku-labs over https

### DIFF
--- a/rails-heroku-tutorial.html
+++ b/rails-heroku-tutorial.html
@@ -163,7 +163,7 @@ end
 <p><em>Note:</em> Heroku makes it clear that Ruby 1.9.3 on Heroku is experimental, which means “no support, the ruby_version will change in the future, and this feature may change or be removed without warning.” In response to an inquiry on January 31, 2012, Heroku said, “there is no timeline yet” to fully support Ruby 1.9.3.</p>
 <p>Install the heroku-labs plugin:</p>
 <p>
-  <code>$ heroku plugins:install http://github.com/heroku/heroku-labs.git</code>
+  <code>$ heroku plugins:install https://github.com/heroku/heroku-labs.git</code>
 </p>
 <p>Enable the “user_env_compile” feature (see Heroku’s <a href="http://devcenter.heroku.com/articles/labs-user-env-compile">documentation</a>):</p>
 <p>


### PR DESCRIPTION
with only http I got: "Could not install heroku-labs..."

see also installation under https://github.com/heroku/heroku-labs 
