### PR TITLE
Remove overriding of bootstrap's icon sprite.

### DIFF
--- a/rails-default-application-layout.html
+++ b/rails-default-application-layout.html
@@ -196,9 +196,6 @@ gem 'bootstrap-sass'
 <p>The file <strong>app/assets/stylesheets/bootstrap_and_overrides.css.scss</strong> is automatically included and compiled into your Rails application.css file by the <code>*= require_tree .</code> statement in the <strong>app/assets/stylesheets/application.css.scss</strong> file.</p>
 <p>Add the file <strong>app/assets/stylesheets/bootstrap_and_overrides.css.scss</strong>:</p>
 <pre>
-// Set the correct sprite paths
-$iconSpritePath: image-url('glyphicons-halflings.png', image);
-$iconWhiteSpritePath: image-url('glyphicons-halflings-white.png', image);
 @import "bootstrap";
 body { padding-top: 60px; }
 @import "bootstrap-responsive";

--- a/tutorial-rails-bootstrap-devise-cancan.html
+++ b/tutorial-rails-bootstrap-devise-cancan.html
@@ -744,9 +744,6 @@ gem 'bootstrap-sass'
 <p>The file <strong>app/assets/stylesheets/bootstrap_and_overrides.css.scss</strong> is automatically included and compiled into your Rails application.css file by the <code>*= require_tree .</code> statement in the <strong>app/assets/stylesheets/application.css.scss</strong> file.</p>
 <p>Add the file <strong>app/assets/stylesheets/bootstrap_and_overrides.css.scss</strong>:</p>
 <pre>
-// Set the correct sprite paths
-$iconSpritePath: image-url('glyphicons-halflings.png');
-$iconWhiteSpritePath: image-url('glyphicons-halflings-white.png');
 @import "bootstrap";
 body { padding-top: 60px; }
 @import "bootstrap-responsive";

--- a/twitter-bootstrap-rails.html
+++ b/twitter-bootstrap-rails.html
@@ -86,9 +86,6 @@ gem 'bootstrap-sass'
 <p>The file <strong>app/assets/stylesheets/bootstrap_and_overrides.css.scss</strong> is automatically included and compiled into your Rails application.css file by the <code>*= require_tree .</code> statement in the <strong>app/assets/stylesheets/application.css.scss</strong> file.</p>
 <p>Add the file <strong>app/assets/stylesheets/bootstrap_and_overrides.css.scss</strong>:</p>
 <pre>
-// Set the correct sprite paths
-$iconSpritePath: image-url('glyphicons-halflings.png');
-$iconWhiteSpritePath: image-url('glyphicons-halflings-white.png');
 @import "bootstrap";
 body { padding-top: 60px; }
 @import "bootstrap-responsive";


### PR DESCRIPTION
Current bootstrap-sass versions have this bug fixed.
